### PR TITLE
WIP: Test dplyr as part of the overall tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 r_github_packages:
   - hadley/devtools
   - hadley/dplyr
-  - hadley/testthat#404
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
 
 r_github_packages:
   - hadley/devtools
+  - hadley/dplyr
+  - hadley/testthat#404
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -1,0 +1,1 @@
+dplyr::test_register_src("dt", src_dt(env = new.env(parent = emptyenv())))

--- a/tests/testthat/test-zzz-dplyr.R
+++ b/tests/testthat/test-zzz-dplyr.R
@@ -1,0 +1,3 @@
+context("zzz-dplyr")
+
+testthat::test_package("dplyr", reporter = NULL)

--- a/tests/testthat/test-zzz-dplyr.R
+++ b/tests/testthat/test-zzz-dplyr.R
@@ -1,3 +1,3 @@
 context("zzz-dplyr")
 
-testthat::test_package("dplyr", reporter = NULL)
+testthat::test_package("dplyr", reporter = get_reporter())


### PR DESCRIPTION
Currently requires hadley/testthat#404.

A few tests fail (but again succeed locally); need to investigate.

@hadley: Is this an approach we want to follow? For this case it would help to have a protected "production" branch in dplyr where only successful builds are accepted.
