### PR TITLE
Pass sort and suffix to merge.data.table

### DIFF
--- a/R/joins.R
+++ b/R/joins.R
@@ -57,17 +57,17 @@ join_dt <- function(op) {
 #' @export
 #' @rdname join.tbl_dt
 #' @importFrom dplyr inner_join
-inner_join.data.table <- join_dt({merge(x, y, by = by$x, allow.cartesian = TRUE)})
+inner_join.data.table <- join_dt({merge(x, y, by = by$x, allow.cartesian = TRUE, ...)})
 
 #' @export
 #' @importFrom dplyr left_join
 #' @rdname join.tbl_dt
-left_join.data.table  <- join_dt({merge(x, y, by = by$x, all.x = TRUE, allow.cartesian = TRUE)})
+left_join.data.table  <- join_dt({merge(x, y, by = by$x, all.x = TRUE, allow.cartesian = TRUE, ...)})
 
 #' @export
 #' @importFrom dplyr right_join
 #' @rdname join.tbl_dt
-right_join.data.table  <- join_dt(merge(x, y, by = by$x, all.y = TRUE, allow.cartesian = TRUE))
+right_join.data.table  <- join_dt(merge(x, y, by = by$x, all.y = TRUE, allow.cartesian = TRUE, ...))
 
 #' @export
 #' @importFrom dplyr semi_join
@@ -88,4 +88,4 @@ anti_join.data.table <- join_dt({x[!y, allow.cartesian = TRUE]})
 #' @importFrom dplyr full_join
 #' @rdname join.tbl_dt
 # http://stackoverflow.com/a/15170956/946850
-full_join.data.table <- join_dt({merge(x, y, by = by$x, all = TRUE, allow.cartesian = TRUE)})
+full_join.data.table <- join_dt({merge(x, y, by = by$x, all = TRUE, allow.cartesian = TRUE, ...)})

--- a/tests/testthat/test-joins.R
+++ b/tests/testthat/test-joins.R
@@ -28,3 +28,16 @@ test_that("joining data tables returns data tables (#470) and does not modify th
     }
   }
 })
+
+test_that("merge.data.table parameters", {
+  a <- data.table(x = c(1, 1, 2, 3), dupname = 4:1)
+  b <- data.table(x = c(1, 2, 2, 4), dupname = 1:4)
+
+  lj <- left_join(a, b, by = "x")
+  expect_true("dupname.x" %in% names(lj))
+  expect_false("dupname.a" %in% names(lj))
+
+  lj <- left_join(a, b, by = "x", suffix = c(".a", ".b"))
+  expect_true("dupname.a" %in% names(lj))
+  expect_false("dupname.x" %in% names(lj))
+})


### PR DESCRIPTION
Allow passing of `sort` and `suffix` from [dplyr](https://github.com/tidyverse/dplyr/blob/master/R/join.r#L87) to `merge.data.table` method in underlying join functions.

Fixes #40 